### PR TITLE
Mock test framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ Dependencies:
  - (neo4j driver) [jcypher](https://github.com/Wolfgang-Schuetzelhofer/jcypher) [wiki](https://github.com/Wolfgang-Schuetzelhofer/jcypher/wiki)
  - (password hasher) [scrypt](https://github.com/wg/scrypt)
  - (logging framework) [slf4j](https://github.com/qos-ch/slf4j)
-
+ - (testing) [restassured](https://github.com/rest-assured/rest-assured/wiki)

--- a/pom.xml
+++ b/pom.xml
@@ -193,15 +193,6 @@
 		<type>test-jar</type>
 		<scope>test</scope>
 	</dependency>
-
-	<!-- JUnit 4 -->
-	<!--	<dependency>
-		<groupId>junit</groupId>
-		<artifactId>junit</artifactId>
-		<version>4.12</version>
-		<scope>compile</scope>
-	</dependency>
-	-->
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <java.version>1.8</java.version>
 
         <!-- pippo (framework) and slf4j (logger) versions -->
-        <pippo.version>0.8.0</pippo.version>
+        <pippo.version>0.9.1</pippo.version>
         <slf4j.version>1.7.7</slf4j.version>
     </properties>
 
@@ -107,9 +107,6 @@
     </build>
 
     <dependencies>
-
-        <!-- pippo <all> dependency coordinates, could slim this down to
-        individual depedencies later on when feature set is known -->
         <dependency>
             <groupId>ro.pippo</groupId>
             <artifactId>pippo-core</artifactId>
@@ -131,7 +128,11 @@
             <version>${pippo.version}</version>
             <type>pom</type>
         </dependency>
-
+        <dependency>
+            <groupId>ro.pippo</groupId>
+            <artifactId>pippo-test</artifactId>
+            <version>${pippo.version}</version>
+        </dependency>
 
         <!-- Logging -->
         <dependency>
@@ -172,19 +173,35 @@
 
         <!-- JavaMail extension -->
     	<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>mail</artifactId>
-			<version>1.4.7</version>
-		</dependency>
+		<groupId>javax.mail</groupId>
+		<artifactId>mail</artifactId>
+		<version>1.4.7</version>
+	</dependency>
 
-		<!-- JUnit 4 -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<scope>test</scope>
-		</dependency>
+	<dependency>
+		<groupId>org.neo4j</groupId>
+		<artifactId>neo4j-kernel</artifactId>
+		<version>2.3.3</version>
+		<type>test-jar</type>
+		<scope>test</scope>
+	</dependency>
+	
+	<dependency>
+		<groupId>org.neo4j</groupId>
+		<artifactId>neo4j-io</artifactId>
+		<version>2.3.3</version>
+		<type>test-jar</type>
+		<scope>test</scope>
+	</dependency>
 
+	<!-- JUnit 4 -->
+	<!--	<dependency>
+		<groupId>junit</groupId>
+		<artifactId>junit</artifactId>
+		<version>4.12</version>
+		<scope>compile</scope>
+	</dependency>
+	-->
     </dependencies>
 
 </project>

--- a/src/test/java/se/lth/cs/connect/TestUserAPI.java
+++ b/src/test/java/se/lth/cs/connect/TestUserAPI.java
@@ -1,0 +1,62 @@
+package se.lth.cs.connect;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.jayway.restassured.response.Response;
+
+import ro.pippo.test.PippoRule;
+import ro.pippo.test.PippoTest;
+
+public class TestUserAPI extends PippoTest {
+
+	@Rule
+	public PippoRule pippoRule = new PippoRule(new Connect());
+	
+	@Test
+	public void testAccessDenied() {
+		// These routes require an active session => they should fail (with status 401)
+		when().get("/v1/account/login").then().statusCode(401);
+		when().get("/v1/account/collections").then().statusCode(401);
+		when().get("/v1/account/self").then().statusCode(401);
+		when().post("/v1/account/logout").then().statusCode(401);
+		when().post("/v1/account/delete").then().statusCode(401);
+		when().post("/v1/account/change-password").then().statusCode(401);
+		when().get("/v1/account/invites").then().statusCode(401);
+		when().get("/v1/account/dat12asm@student.lu.se").then().statusCode(401);
+	}
+	
+	// Register --> Logout --> Login --> Delete
+	@Test
+	public void testLifecycle() {
+		Response reg = given().
+				param("email", "test@serptest.test").
+				param("passw", "hejsanhoppsan").
+			post("/v1/account/register");
+		
+		reg.then().
+			statusCode(200);
+		
+		given().
+			cookie("JSESSIONID", reg.getCookie("JSESSIONID")).
+		when().
+			post("/v1/account/logout").
+		then().
+			statusCode(200);
+		
+		Response login = given().
+				param("email", "test@serptest.test").
+				param("passw", "hejsanhoppsan").
+			post("/v1/account/login");
+		
+		reg.then().
+			statusCode(200);
+		
+		given().
+			cookie("JSESSIONID", login.getCookie("JSESSIONID")).
+		when().
+			post("/v1/account/delete").
+		then().
+			statusCode(200);
+	}
+}


### PR DESCRIPTION
Fixes #17 

We use the pippo test [module](http://www.pippo.ro/doc/testing.html) to handle the server, and [rest assured](https://github.com/rest-assured/rest-assured) for writing nice tests.

How to:
- create a test class that extends `PippoTest` (or `RestAssured` - there is no difference _yet_)
- declare a public @Rule `public PippoRule pippoRule = new PippoRule(new Connect());`
