### PR TITLE
trying to set unkown trustlvl will throw exc

### DIFF
--- a/src/main/java/se/lth/cs/connect/TrustLevel.java
+++ b/src/main/java/se/lth/cs/connect/TrustLevel.java
@@ -6,6 +6,7 @@ public class TrustLevel {
     public static final int USER         = 999;
     public static final int REGISTERED   = 99;
     public static final int UNREGISTERED = 9;
+    public static final int UNKNOWN 	 = -9;
 
     /**
      * Compare access levels of a and b (compare(a,b)):
@@ -44,7 +45,7 @@ public class TrustLevel {
     }
 
     /**
-     * Convert a string representation to int. Unknown string = UNREGISTERED.
+     * Convert a string representation to int. 
      */
     public static int fromString(String repr) {
         switch (repr) {
@@ -53,7 +54,7 @@ public class TrustLevel {
         case "User": return USER;
         case "Registered": return REGISTERED;
         case "Unregistered": return UNREGISTERED;
-        default: return UNREGISTERED;
+        default: return UNKNOWN;
         }
     }
 }

--- a/src/main/java/se/lth/cs/connect/routes/Admin.java
+++ b/src/main/java/se/lth/cs/connect/routes/Admin.java
@@ -95,7 +95,11 @@ public class Admin extends BackendRouter {
             String email = rc.getParameter("email").toString();
             String trust = rc.getParameter("trust").toString();
             int level = TrustLevel.fromString(trust);
-
+            
+            if (level == TrustLevel.UNKNOWN){
+            	throw new RequestException("Invalid trust level.");
+            }
+            
             if (email == null)
                 throw new RequestException("Invalid email.");
 


### PR DESCRIPTION
Server-side will now throw an exception if someone tries to set a trust level that doesn't exist. 
Fixed #34 
