### PR TITLE
Update documentation link to new rtfd url

### DIFF
--- a/docs/user-guide/contributing.md
+++ b/docs/user-guide/contributing.md
@@ -10,7 +10,7 @@ connect is licensed under the BSD 2-clause license.
 
 Documentation
 -------------
-All documentation is avaiable at [readthedocs](https://serp-connect.rtfd.io) for developer guides.
+All documentation is avaiable at [readthedocs](https://serpconnect.rtfd.io) for developer guides.
 
 Depedencies
 -----------


### PR DESCRIPTION
Old link was to my documentation page, new link is to emelie's.