### PR TITLE
resolves #65

### DIFF
--- a/src/main/java/se/lth/cs/connect/modules/AccountSystem.java
+++ b/src/main/java/se/lth/cs/connect/modules/AccountSystem.java
@@ -5,6 +5,9 @@ import se.lth.cs.connect.TrustLevel;
 import java.util.List;
 
 import java.security.SecureRandom;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 import com.lambdaworks.crypto.SCryptUtil;
 
 import iot.jcypher.graph.GrNode;
@@ -131,6 +134,8 @@ public class AccountSystem {
     	JcNode coll = new JcNode("c");
     	JcNode user = new JcNode("user");
     	
+    	ZonedDateTime currentTime = ZonedDateTime.now(ZoneId.of("Europe/Stockholm"));
+    	
         // "Email already exists"
         if (acc != null){
         	//email is already registered
@@ -145,7 +150,7 @@ public class AccountSystem {
 					.property("email").value(email),
 					DO.SET(user.property("trust")).to(trust),
 					DO.SET(user.property("password")).to(acc.password),
-					DO.REMOVE(user.property("date"))
+					DO.SET(user.property("signupdate")).to(currentTime)
 			});
         	return true;
         }
@@ -163,7 +168,7 @@ public class AccountSystem {
                 .property("email").value(email)
                 .property("password").value(acc.password)
                 .property("trust").value(trust)
-                .property("date").value(System.currentTimeMillis())
+                .property("signupdate").value(currentTime)
                 .property("default").value(coll.id())
                 .relation().out().type("MEMBER_OF")
                 .node(coll)
@@ -171,12 +176,12 @@ public class AccountSystem {
                 
         });
         //remove date property from all users that have different trustlevel than unregistered
-        Database.query(Database.access(), new IClause[]{
-                MATCH.node(user).property("email").value(email),
-                   WHERE.valueOf(user.property("trust")).NOT_EQUALS(TrustLevel.UNREGISTERED),
-                   DO.REMOVE(user.property("date"))
-        		
-        });
+//        Database.query(Database.access(), new IClause[]{
+//                MATCH.node(user).property("email").value(email),
+//                   WHERE.valueOf(user.property("trust")).NOT_EQUALS(TrustLevel.UNREGISTERED),
+//                   DO.REMOVE(user.property("date"))
+//        		
+//        });
         return true;
     }
 

--- a/src/main/java/se/lth/cs/connect/modules/AccountSystem.java
+++ b/src/main/java/se/lth/cs/connect/modules/AccountSystem.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import java.security.SecureRandom;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 import com.lambdaworks.crypto.SCryptUtil;
@@ -134,7 +135,7 @@ public class AccountSystem {
     	JcNode coll = new JcNode("c");
     	JcNode user = new JcNode("user");
     	
-    	ZonedDateTime currentTime = ZonedDateTime.now(ZoneId.of("Europe/Stockholm"));
+    	ZonedDateTime currentTime = ZonedDateTime.now(ZoneOffset.UTC);
     	
         // "Email already exists"
         if (acc != null){

--- a/src/main/java/se/lth/cs/connect/modules/AccountSystem.java
+++ b/src/main/java/se/lth/cs/connect/modules/AccountSystem.java
@@ -156,7 +156,6 @@ public class AccountSystem {
         }
             
         // Unless synchronized, email may or may not longer be unique
-
         acc = new Account(email,
             SCryptUtil.scrypt(password, SCRYPT_N, SCRYPT_R, SCRYPT_P), trust);
 
@@ -175,13 +174,6 @@ public class AccountSystem {
   
                 
         });
-        //remove date property from all users that have different trustlevel than unregistered
-//        Database.query(Database.access(), new IClause[]{
-//                MATCH.node(user).property("email").value(email),
-//                   WHERE.valueOf(user.property("trust")).NOT_EQUALS(TrustLevel.UNREGISTERED),
-//                   DO.REMOVE(user.property("date"))
-//        		
-//        });
         return true;
     }
 

--- a/src/main/resources/conf/messages_en.properties
+++ b/src/main/resources/conf/messages_en.properties
@@ -7,4 +7,6 @@ pippo.passwordresetsuccess = Someone (hopefully you) successfully performed a pa
 
 pippo.collectioninvite = You have been invited to a new collection. Please click the link below to head over to your invitations page: {frontend}/invitations.html
 
+pippo.collectioninvitenewuser = You have been invited to a new collection however you aren't registered in our system. Please click the link below to sign up: {frontend}/login.html 
+
 pippo.notifyadminonverify = The following email has registered (and verified the email) to SERP-connect:\n\n{email}


### PR DESCRIPTION
When inviting a user who isn't registered to a collection a different email is being sent which requests the user to sign up. A temporary user with trust level unregistered is being made and linked to the collection invite. If the user ever registers this temporary user will be merged with the user who just registered. Otherwise the temporary users will have to be removed at some point. I will make a separate issue for cleaning out temporary users.  
If you have any thoughts of what the message and title for the emails being sent out should be I'm happy to change.