### PR TITLE
Fix nullptr exception when input to filter is null

### DIFF
--- a/src/main/java/utils/Filter.java
+++ b/src/main/java/utils/Filter.java
@@ -1,10 +1,14 @@
 package utils;
 
 public class Filter {
-	public static String xss(String input){
-		input=input.replaceAll("</", " ");
+	public static String xss(String input) {
+		// Some fields are optional so allow for null here
+		if (input == null)
+			return input;
+
+		input = input.replaceAll("</", " ");
 		input = input.replaceAll("/>", " "); 
-		input=input.replaceAll("<", " ");
+		input = input.replaceAll("<", " ");
 		input = input.replaceAll(">", " "); 
 		return input;
 	}


### PR DESCRIPTION
It is allowed for some fields to be left empty. And to allow
smooth handling of input we should silently ignore null fields
when we try to escape. The real input check is done elsewhere.

Don't trust CircleCI. Don't trust codecov. Don't trust :japanese_goblin: 