### PR TITLE
updated for coll-tax-ext with desc

### DIFF
--- a/src/main/java/se/lth/cs/connect/Connect.java
+++ b/src/main/java/se/lth/cs/connect/Connect.java
@@ -26,6 +26,8 @@ public class Connect extends Application {
 
 	static final String[] CORS_ORIGINS = new String[] { 
 		"http://localhost:8181", 
+		"http://localhost:8182",
+		"https://localhost:8182",  
 		"https://localhost:8181", 
 		"http://localhost:8080",
 

--- a/src/main/java/se/lth/cs/connect/modules/TaxonomyDB.java
+++ b/src/main/java/se/lth/cs/connect/modules/TaxonomyDB.java
@@ -32,7 +32,7 @@ public class TaxonomyDB {
     static String collectionsPath;
 
     public static class Facet {
-    	public String name, id, parent;
+    	public String name, id, parent, desc;
     }
 
     public static class Taxonomy {

--- a/txdb/projects/serp.json
+++ b/txdb/projects/serp.json
@@ -1,4 +1,6 @@
-{
-    "taxonomy": [{"id":"EFFECT","name":"Effect","parent":"root"},{"id":"SCOPE","name":"Scope","parent":"root"},{"id":"CONTEXT","name":"Context","parent":"root"},{"id":"INTERVENTION","name":"Intervention","parent":"root"}],
-    "version": 1
-}
+
+{"taxonomy":[{"name":"Effect","id":"EFFECT","parent":"root","desc":"a short statement of what should be achieved by an intervention. An effect entity is correspondingly a statement of a measured effect"},
+	{"name":"Scope","id":"SCOPE","parent":"root","desc":"the extent of the effect, intended or measured, on the test process. Correspondingly the scope of the challenge describes which part of the testing process is primarily affected by the challenge or desired improvement"},
+	{"name":"Context","id":"CONTEXT","parent":"root","desc":"describes factors restricting the applicability of an intervention"},
+	{"name":"Intervention","id":"INTERVENTION","parent":"root","desc":"an act performed (e.g., use of a technique or a process change) to adapt testing to a specific context, to solve a test issue, to assess testing or to improve testing"}],
+"version":1}


### PR DESCRIPTION
updated TaxonomyDB to take in taxonomy-desc tag.
updated cors_origins in connect.java so live backend works for port8182 so serp & serp-test (or others) can be worked on simultaneously.